### PR TITLE
dockerfile: Make a new directangular/k8s-lock-action image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,4 @@
-FROM alpine:3.12
-
-RUN apk add \
-        bash \
-        curl \
-        jq \
-        py-pip
-RUN pip install awscli
-RUN if ! curl -fL -o /usr/local/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.12/2020-11-02/bin/linux/amd64/kubectl; then \
-        echo >&2 "error: failed to download kubectl binary"; \
-        exit 1; \
-    fi; \
-    chmod +x /usr/local/bin/kubectl
+FROM directangular/k8s-lock-action
 
 COPY main.sh /main.sh
 COPY post.sh /post.sh

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,14 @@
+FROM alpine:3.12
+
+RUN apk add \
+        bash \
+        curl \
+        jq \
+        py-pip \
+        && rm -rf /var/cache/apk/*
+RUN pip install --no-cache-dir awscli
+RUN if ! curl -fL -o /usr/local/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.12/2020-11-02/bin/linux/amd64/kubectl; then \
+        echo >&2 "error: failed to download kubectl binary"; \
+        exit 1; \
+    fi; \
+    chmod +x /usr/local/bin/kubectl

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,9 @@ release:
 	git tag --force v1 origin/master
 	git push --tags --force origin
 	git fetch --tags origin
+
+image: Dockerfile.base
+	docker build . -f Dockerfile.base -t directangular/k8s-lock-action
+
+push: image
+	docker push directangular/k8s-lock-action


### PR DESCRIPTION
Use a new base image so that we can skip installing packages during
the github action.